### PR TITLE
Use Branch Name Instead Of Master

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,10 @@ echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
 branch = ${GITHUB_REF#refs/heads/}
+echo $GITHUB_REF
+echo ${GITHUB_REF#refs/heads/}
+echo "$(echo ${GITHUB_REF#refs/heads/})"
+echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 echo "Checking out $branch branch"
 git fetch
 git checkout origin/$branch

--- a/run.sh
+++ b/run.sh
@@ -22,8 +22,8 @@ git remote add origin https://github.com/${REPO}.git
 
 echo "Checking out Master branch"
 git fetch
-git checkout origin/master
-git checkout -b master
+git checkout origin/production
+git checkout -b production
 
 echo "Exporting token for use with release-it"
 export GITHUB_TOKEN="${TOKEN}"

--- a/run.sh
+++ b/run.sh
@@ -21,10 +21,7 @@ echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
 branch=${GITHUB_REF#refs/heads/}
-echo $GITHUB_REF
-echo ${GITHUB_REF#refs/heads/}
-echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-echo "Checking out ${GITHUB_REF#refs/heads/} branch"
+echo "Checking out $branch branch"
 git fetch
 git checkout origin/$branch
 git checkout -b $branch

--- a/run.sh
+++ b/run.sh
@@ -30,4 +30,4 @@ export GITHUB_TOKEN="${TOKEN}"
 
 echo "Running release-it"
 # $1 is the release type major, minor or patch
-DEBUG=release-it:* release-it --ci --no-npm -- $RELEASE_TYPE --dry-run
+DEBUG=release-it:* release-it --ci --no-npm -- $RELEASE_TYPE

--- a/run.sh
+++ b/run.sh
@@ -23,12 +23,11 @@ git remote add origin https://github.com/${REPO}.git
 branch = ${GITHUB_REF#refs/heads/}
 echo $GITHUB_REF
 echo ${GITHUB_REF#refs/heads/}
-echo "$(echo ${GITHUB_REF#refs/heads/})"
 echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-echo "Checking out $branch branch"
+echo "Checking out $(branch) branch"
 git fetch
-git checkout origin/$branch
-git checkout -b $branch
+git checkout origin/$(branch)
+git checkout -b $(branch)
 
 echo "Exporting token for use with release-it"
 export GITHUB_TOKEN="${TOKEN}"

--- a/run.sh
+++ b/run.sh
@@ -30,4 +30,4 @@ export GITHUB_TOKEN="${TOKEN}"
 
 echo "Running release-it"
 # $1 is the release type major, minor or patch
-DEBUG=release-it:* release-it --ci --no-npm -- $RELEASE_TYPE
+DEBUG=release-it:* release-it $RELEASE_TYPE --ci --no-npm

--- a/run.sh
+++ b/run.sh
@@ -20,10 +20,11 @@ git clone https://github.com/${REPO}.git
 echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
-echo "Checking out Master branch"
+branch = ${GITHUB_REF#refs/heads/}
+echo "Checking out $branch branch"
 git fetch
-git checkout origin/production
-git checkout -b production
+git checkout origin/$branch
+git checkout -b $branch
 
 echo "Exporting token for use with release-it"
 export GITHUB_TOKEN="${TOKEN}"

--- a/run.sh
+++ b/run.sh
@@ -24,10 +24,10 @@ branch = ${GITHUB_REF#refs/heads/}
 echo $GITHUB_REF
 echo ${GITHUB_REF#refs/heads/}
 echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-echo "Checking out $(branch) branch"
+echo "Checking out ${GITHUB_REF#refs/heads/} branch"
 git fetch
-git checkout origin/$(branch)
-git checkout -b $(branch)
+git checkout origin/${branch}
+git checkout -b ${branch}
 
 echo "Exporting token for use with release-it"
 export GITHUB_TOKEN="${TOKEN}"

--- a/run.sh
+++ b/run.sh
@@ -20,14 +20,14 @@ git clone https://github.com/${REPO}.git
 echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
-branch = ${GITHUB_REF#refs/heads/}
+branch=${GITHUB_REF#refs/heads/}
 echo $GITHUB_REF
 echo ${GITHUB_REF#refs/heads/}
 echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 echo "Checking out ${GITHUB_REF#refs/heads/} branch"
 git fetch
-git checkout origin/${branch}
-git checkout -b ${branch}
+git checkout origin/$branch
+git checkout -b $branch
 
 echo "Exporting token for use with release-it"
 export GITHUB_TOKEN="${TOKEN}"

--- a/run.sh
+++ b/run.sh
@@ -30,4 +30,4 @@ export GITHUB_TOKEN="${TOKEN}"
 
 echo "Running release-it"
 # $1 is the release type major, minor or patch
-DEBUG=release-it:* release-it --ci --no-npm
+DEBUG=release-it:* release-it --ci --no-npm -- $RELEASE_TYPE --dry-run


### PR DESCRIPTION
In the public-api repo we have to use branch master for documentation and production for ... production. This fixes that.